### PR TITLE
Add Brian L. Troutwine as signatory.

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,6 +184,7 @@
       <li>Sebastian Jackel, 04/09/2016</li>
       <li>Mike Fikes, 4/9/2016</li>
       <li>Ryan McCuaig, 04/09/2016</li>
+      <li>Brian L. Troutwine (LambdaConf 2015 Speaker) 2016/04/09</li>
       <!-- NOTE(dbp 2016-04-02): To include yourself, add another <li>
            with your name, info, and the date, and then make a pull request! -->
     </ul>


### PR DESCRIPTION
Signed-off-by: Brian L. Troutwine brian@troutwine.us
