### PR TITLE
Add Chad Dollins to statment on lambdaconf

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,6 +228,7 @@
       <li>Kevin Cantú, 2016-04-09</li>
       <li>Michiel Trimpe (CTO at Interactly), 9th of April 2016</li>
       <li>David Cairns, 2016-04-09</li>
+      <li>Chad Dollins, 2016-04-09</li>
       <!-- NOTE(dbp 2016-04-02): To include yourself, add another <li>
            with your name, info, and the date, and then make a pull request! -->
     </ul>


### PR DESCRIPTION
There is no room for hate in this world and implicit tolerance of purveyors of hate speak is unacceptable. As a member of the FP community I would like to be included with the opposition against those seeking to marginalize the disenfranchised.
