### PR TITLE
Add Alethea Rose as an additional signatory

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,6 +288,7 @@
       <li>Andy Wingo (Guile Scheme co-maintainer), 2016-04-10</li>
       <li>Philip Wills, 2016-04-10</li>
       <li>Dmitri G. Brenguz 2016-04-11</li>
+      <li>Alethea Rose, 2016-04-10</li>
       <!-- NOTE(dbp 2016-04-02): To include yourself, add another <li>
            with your name, info, and the date, and then make a pull request! -->
     </ul>


### PR DESCRIPTION
Note: commit signed using a subkey of: `7813 E4FF 06F9 D150 77B9  D7FC 2C37 44A5 1129 7B99`,
which can be verified as the owner of this Github account on [Keybase](https://gist.github.com/alethea/3cc32fd602770d8c20a0).
