### PR TITLE
Remove SCB affiliation, and properly alphabetise Eric

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
       <li>Alex Clemmer (Microsoft, !!Con co-founder)</li>
       <li>Declan Conlon</li>
       <li>Becky Conning</li>
-      <li>Laurence E. Day (Haskell developer, Standard Chartered Bank)</li>
+      <li>Laurence E. Day (Haskell developer)</li>
       <li>Allele Dev</li>
       <li>Reid Draper (Helium)</li>
       <li>Richard Eisenberg (U. of Pennsylvania, GHC implementor, LambdaConf 2015 speaker)</li>
@@ -92,9 +92,9 @@
       <li>Juan Pedro Villa Isaza (Stack Builders)</li>
       <li>Ranjit Jhala (University of California, San Diego; LambdaConf 2015 speaker)</li>
       <li>Joseph Kiniry (Research Lead, Galois; CEO and Chief Scientist, Free &amp; Fair, LambdaConf 2015 contributor)</li>
-      <li>Eric Y Kow (Haskell developer, Standard Chartered Bank)</li>
       <li>Edward Kmett (Haskell developer, HacBoston organizer)</li>
       <li>Geoffery S. Knauth (Lifelong Friend of GNU)</li>
+      <li>Eric Y Kow (Haskell developer)</li>
       <li>Neel Krishnaswami (University of Birmingham)</li>
       <li>Lindsey Kuper (Intel Labs; !!Con co-founder; ICFP Steering Committee member)</li>
       <li>Justin Leitgeb (CTO &amp; Co-Founder, Stack Builders)</li>
@@ -140,7 +140,7 @@
       <li>Stew O’Connor (Typelevel, speaker: Lambdaconf 2015)</li>
       <li>David Van Horn (University of Maryland)</li>
       <li>Philip Wadler</li>
-      <li>Malcolm Wallace (Haskell developer at Standard Chartered Bank)</li>
+      <li>Malcolm Wallace (Haskell developer)</li>
       <li>Stephanie Weirich (University of Pennsylvania)</li>
       <li>John Wiegley</li>
       <li>Brent Yorgey (Hendrix College; former Haskell core library &amp; Haskell.org committees)</li>
@@ -263,8 +263,8 @@
       <li>Adam Neilson (CTO at Rareburg), 2016-04-10</li>
       <li>Jos&eacute; Valim 2016-04-10</li>
       <li>Zans Mihejevs (Haskell developer) 2016-04-10</li>
-      <li>Christopher Kuklewicz (Haskell developer at Standard Chartered Bank)</li>
-      <li>Carlo Hamalainen (Haskell developer at Standard Chartered Bank)</li>
+      <li>Christopher Kuklewicz (Haskell developer)</li>
+      <li>Carlo Hamalainen (Haskell developer)</li>
       <li>Tony Aldridge 2016-04-10</li>
       <li>Andres Cuervo 04/10/2016</li>
       <li>Jeremy Lee, 2016-04-10</li>


### PR DESCRIPTION
We had added our organisation for identification only (as per the disclaimer) but on reflection, it is still better to avoid misunderstanding.
